### PR TITLE
Ignore rest siblings

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports = {
     'no-unexpected-multiline': 'error',
     'no-unneeded-ternary': ['error', {'defaultAssignment': false}],
     'no-unreachable': 'error',
-    'no-unused-vars': 'error',
+    'no-unused-vars': ['error', {'ignoreRestSiblings': true }],
     'no-undef': 'off',
     'no-useless-call': 'error',
     'no-useless-constructor': 'error',


### PR DESCRIPTION
I'm a fan of the pattern of ignoring rest siblings, ie
```
const {a, b, ...noAorB} = someObjectWithAandBmaybe;
use(noAorB);
use(b);
// a is unused but this is fine because we wanted to filter it from noAorB
```

